### PR TITLE
Automatic releases, pull request template and codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@techindicium/central-de-dados

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
+template and use a short description, but in your description aim to include both what the
+change is, and why it is being made, with enough context for anyone to understand. -->
+
+<details>
+  <summary>PR Checklist</summary>
+
+### PR Structure
+
+- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
+- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
+      otherwise).
+
+### Thoroughness
+
+- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
+- [ ] I've updated the docs and README with the added features, breaking changes, new instructions on how to use the repository.
+
+### Release planning
+
+- [ ] I've decided if this PR requires a new major/minor/patch version accordingly to
+    [semver](https://semver.org/), and I've changed the name of the BRANCH to release/* , feature/* or patch/* .
+</details>
+
+### What
+
+[TODO: Short statement about what is changing.]
+
+### Why
+
+[TODO: Why this change is being made. Include any context required to understand the why.]
+
+### Known limitations
+
+[TODO or N/A]

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,5 @@
+template: |
+  ## What's Changed
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -42,14 +42,14 @@ jobs:
           BRANCH_NAME="${{ steps.getbranch.outputs.BRANCH }}"
           CURRENT_VERSION="${{ steps.gettag.outputs.TAG }}"
           IFS='.' read -ra VERSION_PARTS <<< "$CURRENT_VERSION"
-          if [[ $BRANCH_NAME =~ ^release/ ]]; then
+          if [[ $BRANCH_NAME =~ ^(major|release|Major|Release)/ ]]; then
             VERSION_PARTS[0]=$((VERSION_PARTS[0] + 1))
             VERSION_PARTS[1]=0
             VERSION_PARTS[2]=0
-          elif [[ $BRANCH_NAME =~ ^feature/ ]]; then
+          elif [[ $BRANCH_NAME =~ ^(feature|minor|Feature|Minor)/ ]]; then
             VERSION_PARTS[1]=$((VERSION_PARTS[1] + 1))
             VERSION_PARTS[2]=0
-          elif [[ $BRANCH_NAME =~ ^patch/ ]]; then
+          elif [[ $BRANCH_NAME =~ ^(patch|fix|hotfix|Patch|Fix|Hotfix)/ ]]; then
             VERSION_PARTS[2]=$((VERSION_PARTS[2] + 1))
           fi
           NEXT_VERSION="${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.${VERSION_PARTS[2]}"

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,0 +1,70 @@
+name: Release Drafter and Publisher
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  new_release:
+    if: github.event.pull_request.merged == true
+    permissions:
+      # write permission is required to create a github release
+      contents: write
+      # write permission is required for autolabeler
+      # otherwise, read permission is required at least
+      pull-requests: write
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Get branch name
+        id: getbranch
+        run: echo ::set-output name=BRANCH::${GITHUB_HEAD_REF}
+
+      # ${{ github.ref }} was not giving v* as tag name, but refs/tags/v* instead, so I had to abbreviate it
+      - name: Get latest abbreviated tag
+        id: gettag
+        run: echo ::set-output name=TAG::$(git describe --tags $(git rev-list --tags --max-count=1)) # get the latest tag across all branches and put it in the output TAG
+
+      - name: Calculate next version
+        id: nextversion
+        run: |
+          BRANCH_NAME="${{ steps.getbranch.outputs.BRANCH }}"
+          CURRENT_VERSION="${{ steps.gettag.outputs.TAG }}"
+          IFS='.' read -ra VERSION_PARTS <<< "$CURRENT_VERSION"
+          if [[ $BRANCH_NAME =~ ^release/ ]]; then
+            VERSION_PARTS[0]=$((VERSION_PARTS[0] + 1))
+            VERSION_PARTS[1]=0
+            VERSION_PARTS[2]=0
+          elif [[ $BRANCH_NAME =~ ^feature/ ]]; then
+            VERSION_PARTS[1]=$((VERSION_PARTS[1] + 1))
+            VERSION_PARTS[2]=0
+          elif [[ $BRANCH_NAME =~ ^patch/ ]]; then
+            VERSION_PARTS[2]=$((VERSION_PARTS[2] + 1))
+          fi
+          NEXT_VERSION="${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.${VERSION_PARTS[2]}"
+          echo ::set-output name=NEXT_VERSION::"$NEXT_VERSION"
+
+      - name: Create and publish new tag
+        run: |
+          git tag ${{ steps.nextversion.outputs.NEXT_VERSION }}
+          git push origin ${{ steps.nextversion.outputs.NEXT_VERSION }}
+
+      - uses: release-drafter/release-drafter@v5
+        with:
+          commitish: main
+          name: "dbt-snowflake-monitoring ${{ steps.nextversion.outputs.NEXT_VERSION }}"
+          tag: ${{ steps.nextversion.outputs.NEXT_VERSION }}
+          publish: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ From the [SELECT](https://select.dev) team, a dbt package to help you monitor Sn
 
 Pay attention, it is very important to know if your modification to this repository is a release (breaking changes), a feature (functionalities) or a patch(to fix bugs). With that information, create your branch name like this:
 
-- `release/<branch-name>`
-- `feature/<branch-name>`
-- `patch/<branch-name>`
+- `release/<branch-name>` or `major/<branch-name>` or `Release/<branch-name>` or `Major/<branch-name>`
+- `feature/<branch-name>` or `minor/<branch-name>` with capitalised letters work as well
+- `patch/<branch-name>` or `fix/<branch-name>` or `hotfix/<branch-name>` with capitalised letters work as well
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 From the [SELECT](https://select.dev) team, a dbt package to help you monitor Snowflake performance and costs.
 
+## Before creating a branch
+
+Pay attention, it is very important to know if your modification to this repository is a release (breaking changes), a feature (functionalities) or a patch(to fix bugs). With that information, create your branch name like this:
+
+- `release/<branch-name>`
+- `feature/<branch-name>`
+- `patch/<branch-name>`
+
 ## Documentation
 
 Documentation for the package resides on the SELECT website for greater rendering flexibility. For questions and support, please either create an issue or reach out via the Intercom chat bubble on the website 🙂


### PR DESCRIPTION
Now there is no need to manually create tags and releases. We also can rely on an informative structure that is the pull request template, and a direct team you can seek for reviewing your pull request.

The way to use the release action is documented in the README.